### PR TITLE
Fix remaining pep8 issues in analysis.trajectory.

### DIFF
--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -61,9 +61,7 @@ import scipy.stats.mstats
 from iris.analysis._area_weighted import AreaWeightedRegridder
 from iris.analysis._interpolation import (EXTRAPOLATION_MODES,
                                           RectilinearInterpolator)
-
 from iris.analysis._regrid import RectilinearRegridder
-
 import iris.coords
 from iris.exceptions import LazyAggregatorError
 

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -150,7 +150,7 @@ def interpolate(cube, sample_points, method=None):
 
 
     For example::
-    
+
         sample_points = [('latitude', [45, 45, 45]),
         ('longitude', [-60, -50, -40])]
         interpolated_cube = interpolate(cube, sample_points)
@@ -352,7 +352,6 @@ class UnstructuredNearestNeigbourRegridder(object):
         self.trajectory = (('latitude', x_2d.flatten()),
                            ('longitude', y_2d.flatten()))
 
-
     def __call__(self, src_cube):
         # Check source cube matches original.
         # For now, just a shape match will do.
@@ -362,7 +361,7 @@ class UnstructuredNearestNeigbourRegridder(object):
 
         # Get the basic interpolated results.
         result_trajectory_cube = interpolate(src_cube, self.trajectory,
-                                       method='nearest')
+                                             method='nearest')
 
         # Reconstruct this as a cube "like" the source data.
         # TODO: sort out aux-coords, cell methods, cell measures ??

--- a/lib/iris/tests/test_coding_standards.py
+++ b/lib/iris/tests/test_coding_standards.py
@@ -80,7 +80,6 @@ class StandardReportWithExclusions(pep8.StandardReport):
     expected_bad_files = [
         '*/iris/std_names.py',
         '*/iris/analysis/_interpolate_private.py',
-        '*/iris/analysis/trajectory.py',
         '*/iris/fileformats/cf.py',
         '*/iris/fileformats/dot.py',
         '*/iris/fileformats/grib/__init__.py',


### PR DESCRIPTION
Tiny tiny tweaks to fix pep8 and include-list standards

@corinnebosley branch target,
makes this "additional" to [iris#2249](https://github.com/SciTools/iris/pull/2249)