### PR TITLE
Fix contiguity checking

### DIFF
--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -47,6 +47,7 @@ import iris.cube
 import iris.analysis.cartography as cartography
 import iris.coords
 import iris.coord_systems
+from iris.coords import discontiguity_check_2d
 from iris.exceptions import IrisError
 # Importing iris.palette to register the brewer palettes.
 import iris.palette
@@ -289,7 +290,7 @@ def _check_contiguity_and_bounds(coord, data, abs_tol=1e-4):
 
     """
     both_dirs_contiguous, diffs_along_x, diffs_along_y = \
-        iris.coords.discontinuity_check_2d(coord, abs_tol=abs_tol)
+        iris.coords.discontiguity_check_2d(coord, abs_tol=abs_tol)
 
     if not both_dirs_contiguous:
 
@@ -338,11 +339,12 @@ def _draw_2d_from_bounds(draw_method_name, cube, *args, **kwargs):
     for coord in plot_defn.coords:
         if coord.ndim == 2:
             try:
-                _check_contiguity_and_bounds(coord.bounds, data=cube.data,
-                                             abs_tol=two_dim_contig_atol)
+                discontiguity_check_2d(coord, data=cube.data,
+                                       abs_tol=two_dim_contig_atol)
             except ValueError:
-                if _check_contiguity_and_bounds(coord.bounds.T, data=cube.data,
-                                                abs_tol=two_dim_contig_atol)\
+                if discontiguity_check_2d(coord, data=cube.data,
+                                          abs_tol=two_dim_contig_atol,
+                                          transpose=True)\
                         is True:
                     plot_defn.transpose = True
 

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -289,7 +289,7 @@ def _check_contiguity_and_bounds(coord, data, abs_tol=1e-4):
 
     """
     both_dirs_contiguous, diffs_along_x, diffs_along_y = \
-        iris.coords._discontinuity_in_2d_bounds(coord.bounds, abs_tol=abs_tol)
+        iris.coords.discontinuity_check_2d(coord, abs_tol=abs_tol)
 
     if not both_dirs_contiguous:
 


### PR DESCRIPTION
This is a fix and a possible simplification for contiguity checking of the coordinate bounds.

Previous implementation tried to check that the bounds matched up in both directions on the same coordinate (e.g. longitude), but the bounds arrays only represent one direction for each coordinate (i.e. longitude bounds only contain x-values, latitude bounds only contain y-values), so it makes sense to check x-contiguity for the x-coord and y-contiguity for the y-coord.

I have also started joining and replacing some functions/methods for simplicity.